### PR TITLE
[iOS 7.0 bug] offset at the bottom (fixed)

### DIFF
--- a/ASDepthModal/ASDepthModalViewController.m
+++ b/ASDepthModal/ASDepthModalViewController.m
@@ -143,20 +143,24 @@ static NSInteger const kDepthModalOptionTapMask = 1 << 9;
         self.rootViewController.view.layer.cornerRadius = ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad?kDefaultiPadCornerRadius:kDefaultiPhoneCornerRadius);
         // Take care of the status bar only if the frame is full screen, which depends on the View controller type.
         // For example, frame is full screen with UINavigationController, but not with basic UIViewController.
-        if(UIInterfaceOrientationIsPortrait(self.rootViewController.interfaceOrientation))
+        if ([self.rootViewController isKindOfClass:[UINavigationController class]])
         {
-            if(frame.size.height == window.bounds.size.height)
+            if(UIInterfaceOrientationIsPortrait(self.rootViewController.interfaceOrientation))
             {
-                frame.size.height -= [UIApplication sharedApplication].statusBarFrame.size.height;
+                if(frame.size.height == window.bounds.size.height)
+                {
+                    frame.size.height -= [UIApplication sharedApplication].statusBarFrame.size.height;
+                }
+            }
+            else
+            {
+                if(frame.size.width == window.bounds.size.width)
+                {
+                    frame.size.width -= [UIApplication sharedApplication].statusBarFrame.size.width;
+                }
             }
         }
-        else
-        {
-            if(frame.size.width == window.bounds.size.width)
-            {
-                frame.size.width -= [UIApplication sharedApplication].statusBarFrame.size.width;
-            }
-        }
+
     }
     self.view.transform = self.rootViewController.view.transform;
     self.rootViewController.view.transform = CGAffineTransformIdentity;


### PR DESCRIPTION
fixed a bug which caused an offset (equivalent to the status bar height) at the bottom when model appears (under iOS 7.0)
